### PR TITLE
fix: Include super admin role

### DIFF
--- a/pkg/connector/account.go
+++ b/pkg/connector/account.go
@@ -82,7 +82,7 @@ func (acc *accountResourceType) Entitlements(ctx context.Context, resource *v2.R
 }
 
 func (acc *accountResourceType) Grants(ctx context.Context, resource *v2.Resource, token *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
-	// parse the roleIds from the users
+	// parse the roleIDs from the users
 	bag, err := parsePageToken(token.Token, &v2.ResourceId{ResourceType: resourceTypeUser.Id})
 	if err != nil {
 		return nil, "", nil, err

--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -55,6 +55,18 @@ func filterUsersByRole(id string, users []hubspot.User) []hubspot.User {
 	return filteredUsers
 }
 
+func filterUsersBySuperAdmin(users []hubspot.User) []hubspot.User {
+	var superAdmins []hubspot.User
+
+	for _, user := range users {
+		if user.SuperAdmin {
+			superAdmins = append(superAdmins, user)
+		}
+	}
+
+	return superAdmins
+}
+
 func containsTeam(tIds []string, targetTeam string) bool {
 	for _, id := range tIds {
 		if id == targetTeam {

--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -44,7 +44,7 @@ func filterUsersByRole(id string, users []hubspot.User) []hubspot.User {
 	var filteredUsers []hubspot.User
 
 	for _, user := range users {
-		for _, roleId := range user.RoleIds {
+		for _, roleId := range user.RoleIDs {
 			if roleId == id {
 				filteredUsers = append(filteredUsers, user)
 				break
@@ -67,8 +67,8 @@ func filterUsersBySuperAdmin(users []hubspot.User) []hubspot.User {
 	return superAdmins
 }
 
-func containsTeam(tIds []string, targetTeam string) bool {
-	for _, id := range tIds {
+func containsTeam(tIDs []string, targetTeam string) bool {
+	for _, id := range tIDs {
 		if id == targetTeam {
 			return true
 		}
@@ -77,10 +77,10 @@ func containsTeam(tIds []string, targetTeam string) bool {
 	return false
 }
 
-func removeTeam(tIds []string, targetTeam string) []string {
-	tv := make([]string, 0, len(tIds))
+func removeTeam(tIDs []string, targetTeam string) []string {
+	tv := make([]string, 0, len(tIDs))
 
-	for _, id := range tIds {
+	for _, id := range tIDs {
 		if id != targetTeam {
 			tv = append(tv, id)
 		}

--- a/pkg/hubspot/client.go
+++ b/pkg/hubspot/client.go
@@ -156,7 +156,7 @@ func (c *Client) GetRoles(ctx context.Context) ([]Role, annotations.Annotations,
 type UpdateUserPayload struct {
 	RoleId           string   `json:"roleId,omitempty"`
 	PrimaryTeamId    string   `json:"primaryTeamId,omitempty"`
-	SecondaryTeamIds []string `json:"secondaryTeamIds,omitempty"`
+	SecondaryTeamIDs []string `json:"secondaryTeamIds,omitempty"`
 }
 
 // UpdateUser updates information about provided user.

--- a/pkg/hubspot/models.go
+++ b/pkg/hubspot/models.go
@@ -10,6 +10,7 @@ type User struct {
 	RoleIds          []string `json:"roleIds"`
 	TeamId           string   `json:"primaryTeamId"`
 	SecondaryTeamIds []string `json:"secondaryTeamIds"`
+	SuperAdmin       bool     `json:"superAdmin"`
 }
 
 type Team struct {
@@ -27,6 +28,15 @@ type Account struct {
 type Role struct {
 	BaseResource
 	Name string `json:"name"`
+}
+
+func NewRole(id, name string) *Role {
+	return &Role{
+		BaseResource: BaseResource{
+			Id: id,
+		},
+		Name: name,
+	}
 }
 
 type Page struct {

--- a/pkg/hubspot/models.go
+++ b/pkg/hubspot/models.go
@@ -7,17 +7,17 @@ type BaseResource struct {
 type User struct {
 	BaseResource
 	Email            string   `json:"email"`
-	RoleIds          []string `json:"roleIds"`
+	RoleIDs          []string `json:"roleIds"`
 	TeamId           string   `json:"primaryTeamId"`
-	SecondaryTeamIds []string `json:"secondaryTeamIds"`
+	SecondaryTeamIDs []string `json:"secondaryTeamIds"`
 	SuperAdmin       bool     `json:"superAdmin"`
 }
 
 type Team struct {
 	BaseResource
 	Name             string   `json:"name"`
-	UserIds          []string `json:"userIds"`
-	SecondaryUserIds []string `json:"secondaryUserIds"`
+	UserIDs          []string `json:"userIds"`
+	SecondaryUserIDs []string `json:"secondaryUserIds"`
 }
 
 type Account struct {


### PR DESCRIPTION
This PR fixes syncing of roles. Super Admin is not included when listing roles - added it as a concrete baton resource and implemented grants for these users.