### PR TITLE
[BB-1052] Ignore errors retrieving user last login during sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@ To obtain an API key, you need to create an account in HubSpot and create a priv
 
 Be aware that to sync also the user or team roles, you have to have an enterprise account since these roles are available only under enterprise account.
 
+## Permissions
+
+| API                                      | Required Scopes                                      | Purpose                      |
+|-------------------------------------------|------------------------------------------------------|------------------------------|
+| GET /settings/v3/users                    | `crm.objects.users.read` or `settings.users.read`     | Retrieve users               |
+| POST /crm/v3/objects/users/search         | `crm.objects.users.read`                              | Retrieve deactivated users   |
+| GET /settings/v3/users/teams              | `settings.users.teams.read`                           | Retrieve teams               |
+| GET /settings/v3/users/roles              | `crm.objects.users.read` or `settings.users.read`     | Retrieve roles               |
+| GET /account-info/v3/details              | `account-info.read`                                   | Retrieve account details     |
+| GET /account-info/v3/activity/login       | `account-info.security.read`                          | Get user last login activity |
+
 # Getting Started
 
 ## brew

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -64,8 +65,12 @@ func (c *userResourceType) userResource(ctx context.Context, user *hubspot.User,
 
 	lastLogin, _, err := c.client.GetUserLastLogin(ctx, user.Id)
 	if err != nil {
-		l := ctxzap.Extract(ctx)
-		l.Warn("failed to get last login activity", zap.String("user_id", user.Id), zap.Error(err))
+		if s, ok := status.FromError(err); ok && s.Code() == 403 {
+			l := ctxzap.Extract(ctx)
+			l.Warn("baton-hubspot: failed to get last login activity: permission denied", zap.String("user_id", user.Id), zap.Error(err))
+		} else {
+			return nil, nil, err
+		}
 	}
 	if lastLogin != nil {
 		userTraitOptions = append(userTraitOptions, rs.WithLastLogin(*lastLogin))

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -63,13 +63,13 @@ func (c *userResourceType) userResource(ctx context.Context, user *hubspot.User,
 		rs.WithStatus(userState),
 	}
 
-	lastLogin, _, err := c.client.GetUserLastLogin(ctx, user.Id)
+	lastLogin, annos, err := c.client.GetUserLastLogin(ctx, user.Id)
 	if err != nil {
 		if s, ok := status.FromError(err); ok && s.Code() == 403 {
 			l := ctxzap.Extract(ctx)
 			l.Warn("baton-hubspot: failed to get last login activity: permission denied", zap.String("user_id", user.Id), zap.Error(err))
 		} else {
-			return nil, nil, err
+			return nil, annos, err
 		}
 	}
 	if lastLogin != nil {

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -10,6 +10,9 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/pagination"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
 )
 
 const (
@@ -59,9 +62,10 @@ func (c *userResourceType) userResource(ctx context.Context, user *hubspot.User,
 		rs.WithStatus(userState),
 	}
 
-	lastLogin, annos, err := c.client.GetUserLastLogin(ctx, user.Id)
+	lastLogin, _, err := c.client.GetUserLastLogin(ctx, user.Id)
 	if err != nil {
-		return nil, annos, fmt.Errorf("failed to get last login activity %w", err)
+		l := ctxzap.Extract(ctx)
+		l.Warn("failed to get last login activity", zap.String("user_id", user.Id), zap.Error(err))
 	}
 	if lastLogin != nil {
 		userTraitOptions = append(userTraitOptions, rs.WithLastLogin(*lastLogin))

--- a/pkg/hubspot/client.go
+++ b/pkg/hubspot/client.go
@@ -243,6 +243,8 @@ func (c *Client) GetDeletedUsers(ctx context.Context, pageOptions GetUsersVars) 
 	return ids, "", annos, nil
 }
 
+// GetUserLastLogin returns the last login time for a user.
+// The /account-info/v3/activity/login endpoint requires account-info.security.read scope.
 func (c *Client) GetUserLastLogin(ctx context.Context, userId string) (*time.Time, annotations.Annotations, error) {
 	queryParams := setupPaginationQuery(url.Values{}, 5, "")
 	var accountLoginResponse AccountLoginResponse


### PR DESCRIPTION
If we are unable to retrieve the user's last login information, continue to sync the user without it.