### PR TITLE
[BB-1280] always list super admin role

### DIFF
--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -62,10 +62,6 @@ func (r *roleResourceType) List(ctx context.Context, parentId *v2.ResourceId, _ 
 	}
 
 	roles, annotations, _ := r.client.GetRoles(ctx)
-	if roles == nil {
-		// do not list user entitlements when account does not support roles
-		return nil, "", annotations, nil
-	}
 
 	var rv []*v2.Resource
 	for _, role := range roles {
@@ -175,6 +171,10 @@ func (r *roleResourceType) Grant(ctx context.Context, principal *v2.Resource, en
 
 	roleId := entitlement.Resource.Id.Resource
 
+	if roleId == superAdminRole {
+		return nil, fmt.Errorf("hubspot-connector: super admin role can not be provisioned via API")
+	}
+
 	// no need to check current user role - only rewriting is supported
 	// grant role membership
 	annos, err := r.client.UpdateUser(
@@ -204,6 +204,11 @@ func (r *roleResourceType) Revoke(ctx context.Context, grant *v2.Grant) (annotat
 		)
 
 		return nil, fmt.Errorf("hubspot-connector: only users can have role membership revoked")
+	}
+
+	roleId := grant.Entitlement.Resource.Id.Resource
+	if roleId == superAdminRole {
+		return nil, fmt.Errorf("hubspot-connector: super admin role can not be revoked via API")
 	}
 
 	// revoke role membership


### PR DESCRIPTION
Free accounts do not have access to list roles, but super_admin is a boolean field in the user object, so we always list it as role.
The api does not support modifying this user.super_admin field, so we return an error if grant or revoke is for super_admin role. 