### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/cmd/baton-hubspot/main.go
+++ b/cmd/baton-hubspot/main.go
@@ -42,7 +42,7 @@ func main() {
 func getConnector(ctx context.Context, hsc *cfg.Hubspot) (types.ConnectorServer, error) {
 	l := ctxzap.Extract(ctx)
 
-	hubspotConnector, err := connector.New(ctx, hsc.Token, hsc.UserStatus)
+	hubspotConnector, err := connector.New(ctx, hsc.Token, hsc.UserStatus, hsc.BaseUrl)
 	if err != nil {
 		l.Error("error creating connector", zap.Error(err))
 		return nil, err

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -6,6 +6,7 @@ import "reflect"
 type Hubspot struct {
 	Token string `mapstructure:"token"`
 	UserStatus bool `mapstructure:"user-status"`
+	BaseUrl string `mapstructure:"base-url"`
 }
 
 func (c *Hubspot) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,11 +18,15 @@ var (
 		field.WithDescription("Enables user status syncing. WARNING: Additional token scope needed: 'crm.objects.users.read'. ($BATON_USER_STATUS)"),
 		field.WithDefaultValue(false),
 	)
+	BaseURLField = field.StringField(
+		"base-url",
+		field.WithDescription("Override the HubSpot API URL (for testing)"),
+	)
 )
 
 //go:generate go run ./gen
 var Config = field.NewConfiguration(
-	[]field.SchemaField{TokenField, UserStatusField},
+	[]field.SchemaField{TokenField, UserStatusField, BaseURLField},
 	field.WithConnectorDisplayName("HubSpot"),
 	field.WithHelpUrl("/docs/baton/hubspot"),
 	field.WithIconUrl("/static/app-icons/hubspot.svg"),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,6 +21,7 @@ var (
 	BaseURLField = field.StringField(
 		"base-url",
 		field.WithDescription("Override the HubSpot API URL (for testing)"),
+		field.WithHidden(true),
 	)
 )
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,6 +22,7 @@ var (
 		"base-url",
 		field.WithDescription("Override the HubSpot API URL (for testing)"),
 		field.WithHidden(true),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
 )
 

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -75,7 +75,7 @@ func (hs *HubSpot) Validate(ctx context.Context) (annotations.Annotations, error
 }
 
 // New returns the HubSpot connector.
-func New(ctx context.Context, accessToken string, userStatus bool) (*HubSpot, error) {
+func New(ctx context.Context, accessToken string, userStatus bool, baseURL string) (*HubSpot, error) {
 	httpClient, err := uhttp.NewClient(ctx, uhttp.WithLogger(true, ctxzap.Extract(ctx)))
 
 	if err != nil {
@@ -83,7 +83,7 @@ func New(ctx context.Context, accessToken string, userStatus bool) (*HubSpot, er
 	}
 
 	return &HubSpot{
-		client:     hubspot.NewClient(accessToken, httpClient),
+		client:     hubspot.NewClient(accessToken, httpClient, baseURL),
 		userStatus: userStatus,
 	}, nil
 }

--- a/pkg/hubspot/client.go
+++ b/pkg/hubspot/client.go
@@ -18,20 +18,42 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-const BaseURL = "https://api.hubapi.com/"
-const UsersBaseURL = BaseURL + "settings/v3/users"
-const UserBaseURL = BaseURL + "settings/v3/users/%s"
-const TeamsBaseURL = BaseURL + "settings/v3/users/teams"
-const RolesBaseURL = BaseURL + "settings/v3/users/roles"
-const AccountBaseURL = BaseURL + "account-info/v3/details"
-const SearchUserObjectURL = BaseURL + "crm/v3/objects/users/search"
-const AccountLastLogin = BaseURL + "account-info/v3/activity/login"
+const DefaultBaseURL = "https://api.hubapi.com/"
 const EqualOperator = "EQ"
 const HSInternalUserId = "hs_internal_user_id"
 
 type Client struct {
 	httpClient  *http.Client
 	accessToken string
+	baseURL     string
+}
+
+func (c *Client) usersURL() string {
+	return c.baseURL + "settings/v3/users"
+}
+
+func (c *Client) userURL(userID string) string {
+	return fmt.Sprintf(c.baseURL+"settings/v3/users/%s", userID)
+}
+
+func (c *Client) teamsURL() string {
+	return c.baseURL + "settings/v3/users/teams"
+}
+
+func (c *Client) rolesURL() string {
+	return c.baseURL + "settings/v3/users/roles"
+}
+
+func (c *Client) accountURL() string {
+	return c.baseURL + "account-info/v3/details"
+}
+
+func (c *Client) searchUserObjectURL() string {
+	return c.baseURL + "crm/v3/objects/users/search"
+}
+
+func (c *Client) accountLastLoginURL() string {
+	return c.baseURL + "account-info/v3/activity/login"
 }
 
 type UsersResponse struct {
@@ -84,10 +106,14 @@ type SearchUserObjectPayload struct {
 	After        string    `json:"after,omitempty"`
 }
 
-func NewClient(accessToken string, httpClient *http.Client) *Client {
+func NewClient(accessToken string, httpClient *http.Client, baseURL string) *Client {
+	if baseURL == "" {
+		baseURL = DefaultBaseURL
+	}
 	return &Client{
 		accessToken: accessToken,
 		httpClient:  httpClient,
+		baseURL:     baseURL,
 	}
 }
 
@@ -112,7 +138,7 @@ func (c *Client) GetUsers(ctx context.Context, getUsersVars GetUsersVars) ([]Use
 
 	annos, err := c.get(
 		ctx,
-		UsersBaseURL,
+		c.usersURL(),
 		&userResponse,
 		queryParams,
 	)
@@ -133,7 +159,7 @@ func (c *Client) GetTeams(ctx context.Context) ([]Team, annotations.Annotations,
 	var teamResponse TeamsResponse
 	annos, err := c.get(
 		ctx,
-		TeamsBaseURL,
+		c.teamsURL(),
 		&teamResponse,
 		nil,
 	)
@@ -150,7 +176,7 @@ func (c *Client) GetAccount(ctx context.Context) (Account, annotations.Annotatio
 	var accountResponse Account
 	annos, err := c.get(
 		ctx,
-		AccountBaseURL,
+		c.accountURL(),
 		&accountResponse,
 		nil,
 	)
@@ -167,7 +193,7 @@ func (c *Client) GetUser(ctx context.Context, userId string) (User, annotations.
 	var userResponse User
 	annos, err := c.get(
 		ctx,
-		fmt.Sprintf(UserBaseURL, userId),
+		c.userURL(userId),
 		&userResponse,
 		nil,
 	)
@@ -181,7 +207,7 @@ func (c *Client) GetUser(ctx context.Context, userId string) (User, annotations.
 // GetRoles returns all roles under a single account.
 func (c *Client) GetRoles(ctx context.Context) ([]Role, annotations.Annotations, error) {
 	var rolesResponse RolesResponse
-	annos, err := c.get(ctx, RolesBaseURL, &rolesResponse, nil)
+	annos, err := c.get(ctx, c.rolesURL(), &rolesResponse, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -199,7 +225,7 @@ type UpdateUserPayload struct {
 func (c *Client) UpdateUser(ctx context.Context, userId string, payload *UpdateUserPayload) (annotations.Annotations, error) {
 	annos, err := c.put(
 		ctx,
-		fmt.Sprintf(UserBaseURL, userId),
+		c.userURL(userId),
 		payload,
 		nil,
 	)
@@ -226,7 +252,7 @@ func (c *Client) GetDeletedUsers(ctx context.Context, pageOptions GetUsersVars) 
 	var res SearchUserObjectResponse
 	annos, err := c.post(
 		ctx,
-		SearchUserObjectURL,
+		c.searchUserObjectURL(),
 		payload,
 		&res,
 	)
@@ -252,7 +278,7 @@ func (c *Client) GetUserLastLogin(ctx context.Context, userId string) (*time.Tim
 
 	annos, err := c.get(
 		ctx,
-		AccountLastLogin,
+		c.accountLastLoginURL(),
 		&accountLoginResponse,
 		queryParams,
 	)

--- a/pkg/hubspot/client.go
+++ b/pkg/hubspot/client.go
@@ -339,7 +339,7 @@ func (c *Client) doRequest(
 	req.Header.Add("Accept", "application/json")
 	req.Header.Add("Content-Type", "application/json")
 
-	rawResponse, err := c.httpClient.Do(req)
+	rawResponse, err := c.httpClient.Do(req) //nolint:gosec,nolintlint // G704: URL constructed from trusted config
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
cmd/baton-hubspot/main.go,pkg/config/conf.gen.go,pkg/config/config.go,pkg/connector/connector.go,pkg/hubspot/client.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-hubspot --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.