### PR TITLE
[CXP-454] refactor to use resourcesyncerv2 and session store

### DIFF
--- a/cmd/baton-hubspot/main.go
+++ b/cmd/baton-hubspot/main.go
@@ -2,16 +2,13 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"os"
 
 	cfg "github.com/conductorone/baton-hubspot/pkg/config"
 	"github.com/conductorone/baton-hubspot/pkg/connector"
+	"github.com/conductorone/baton-sdk/pkg/cli"
 	"github.com/conductorone/baton-sdk/pkg/config"
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
-	"github.com/conductorone/baton-sdk/pkg/types"
-	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
-	"go.uber.org/zap"
+	"github.com/conductorone/baton-sdk/pkg/connectorrunner"
 )
 
 var version = "dev"
@@ -19,40 +16,21 @@ var version = "dev"
 func main() {
 	ctx := context.Background()
 
-	_, cmd, err := config.DefineConfiguration(
+	config.RunConnector(
 		ctx,
 		"baton-hubspot",
-		getConnector,
+		version,
 		cfg.Config,
+		getConnector,
+		connectorrunner.WithDefaultCapabilitiesConnectorBuilderV2(&connector.HubSpot{}),
+		connectorrunner.WithSessionStoreEnabled(),
 	)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
-	}
-
-	cmd.Version = version
-
-	err = cmd.Execute()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
-	}
 }
 
-func getConnector(ctx context.Context, hsc *cfg.Hubspot) (types.ConnectorServer, error) {
-	l := ctxzap.Extract(ctx)
-
-	hubspotConnector, err := connector.New(ctx, hsc.Token, hsc.UserStatus, hsc.BaseUrl)
+func getConnector(ctx context.Context, hsc *cfg.Hubspot, _ *cli.ConnectorOpts) (connectorbuilder.ConnectorBuilderV2, []connectorbuilder.Opt, error) {
+	c, err := connector.New(ctx, hsc.Token, hsc.UserStatus, hsc.BaseUrl)
 	if err != nil {
-		l.Error("error creating connector", zap.Error(err))
-		return nil, err
+		return nil, nil, err
 	}
-
-	connector, err := connectorbuilder.NewConnector(ctx, hubspotConnector)
-	if err != nil {
-		l.Error("error creating connector", zap.Error(err))
-		return nil, err
-	}
-
-	return connector, nil
+	return c, nil, nil
 }

--- a/pkg/connector/account.go
+++ b/pkg/connector/account.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/conductorone/baton-hubspot/pkg/hubspot"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
-	"github.com/conductorone/baton-sdk/pkg/annotations"
-	"github.com/conductorone/baton-sdk/pkg/pagination"
 	ent "github.com/conductorone/baton-sdk/pkg/types/entitlement"
 	grant "github.com/conductorone/baton-sdk/pkg/types/grant"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
@@ -45,24 +43,24 @@ func accountResource(_ context.Context, account *hubspot.Account, parentResource
 	return resource, nil
 }
 
-func (acc *accountResourceType) List(ctx context.Context, parentId *v2.ResourceId, token *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
-	account, annotations, err := acc.client.GetAccount(ctx)
+func (acc *accountResourceType) List(ctx context.Context, parentId *v2.ResourceId, _ rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
+	account, annos, err := acc.client.GetAccount(ctx)
 	if err != nil {
-		return nil, "", nil, fmt.Errorf("hubspot-connector: failed to list account: %w", err)
+		return nil, nil, fmt.Errorf("hubspot-connector: failed to list account: %w", err)
 	}
 
 	var rv []*v2.Resource
 	accountCopy := account
 	ar, err := accountResource(ctx, &accountCopy, parentId)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 	rv = append(rv, ar)
 
-	return rv, "", annotations, nil
+	return rv, &rs.SyncOpResults{Annotations: annos}, nil
 }
 
-func (acc *accountResourceType) Entitlements(ctx context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
+func (acc *accountResourceType) Entitlements(_ context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
 	var rv []*v2.Entitlement
 
 	assignmentOptions := []ent.EntitlementOption{
@@ -71,50 +69,41 @@ func (acc *accountResourceType) Entitlements(ctx context.Context, resource *v2.R
 		ent.WithDescription(fmt.Sprintf("Account %s role in HubSpot", resource.DisplayName)),
 	}
 
-	// create the membership entitlement
 	rv = append(rv, ent.NewAssignmentEntitlement(
 		resource,
 		accountMembership,
 		assignmentOptions...,
 	))
 
-	return rv, "", nil, nil
+	return rv, nil, nil
 }
 
-func (acc *accountResourceType) Grants(ctx context.Context, resource *v2.Resource, token *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
-	// parse the roleIDs from the users
-	bag, err := parsePageToken(token.Token, &v2.ResourceId{ResourceType: resourceTypeUser.Id})
+func (acc *accountResourceType) Grants(ctx context.Context, resource *v2.Resource, opts rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
+	bag, err := parsePageToken(opts.PageToken.Token, &v2.ResourceId{ResourceType: resourceTypeUser.Id})
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
-	users, nextToken, annotations, err := acc.client.GetUsers(
+	users, nextToken, annos, err := acc.client.GetUsers(
 		ctx,
 		hubspot.GetUsersVars{Limit: ResourcesPageSize, After: bag.PageToken()},
 	)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	pageToken, err := bag.NextToken(nextToken)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	var rv []*v2.Grant
 	for _, user := range users {
 		userResourceId := getUserResourceId(user.Id)
-		rv = append(
-			rv,
-			grant.NewGrant(
-				resource,
-				accountMembership,
-				userResourceId,
-			),
-		)
+		rv = append(rv, grant.NewGrant(resource, accountMembership, userResourceId))
 	}
 
-	return rv, pageToken, annotations, nil
+	return rv, &rs.SyncOpResults{NextPageToken: pageToken, Annotations: annos}, nil
 }
 
 func accountBuilder(client *hubspot.Client) *accountResourceType {

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -47,8 +47,8 @@ type HubSpot struct {
 	userStatus bool
 }
 
-func (hs *HubSpot) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncer {
-	return []connectorbuilder.ResourceSyncer{
+func (hs *HubSpot) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncerV2 {
+	return []connectorbuilder.ResourceSyncerV2{
 		accountBuilder(hs.client),
 		teamBuilder(hs.client),
 		userBuilder(hs.client, hs.userStatus),

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -7,7 +7,6 @@ import (
 	"github.com/conductorone/baton-hubspot/pkg/hubspot"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
-	"github.com/conductorone/baton-sdk/pkg/pagination"
 	ent "github.com/conductorone/baton-sdk/pkg/types/entitlement"
 	grant "github.com/conductorone/baton-sdk/pkg/types/grant"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
@@ -56,12 +55,12 @@ func roleResource(role *hubspot.Role, parentResourceID *v2.ResourceId) (*v2.Reso
 	return resource, nil
 }
 
-func (r *roleResourceType) List(ctx context.Context, parentId *v2.ResourceId, _ *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+func (r *roleResourceType) List(ctx context.Context, parentId *v2.ResourceId, _ rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
 	if parentId == nil {
-		return nil, "", nil, nil
+		return nil, nil, nil
 	}
 
-	roles, annotations, _ := r.client.GetRoles(ctx)
+	roles, annos, _ := r.client.GetRoles(ctx)
 
 	var rv []*v2.Resource
 	for _, role := range roles {
@@ -69,7 +68,7 @@ func (r *roleResourceType) List(ctx context.Context, parentId *v2.ResourceId, _ 
 
 		rr, err := roleResource(&roleCopy, parentId)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		rv = append(rv, rr)
@@ -79,15 +78,15 @@ func (r *roleResourceType) List(ctx context.Context, parentId *v2.ResourceId, _ 
 	saRole := hubspot.NewRole(superAdminRole, "Super Admin")
 	sar, err := roleResource(saRole, parentId)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	rv = append(rv, sar)
 
-	return rv, "", annotations, nil
+	return rv, &rs.SyncOpResults{Annotations: annos}, nil
 }
 
-func (r *roleResourceType) Entitlements(ctx context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
+func (r *roleResourceType) Entitlements(_ context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
 	var rv []*v2.Entitlement
 
 	assignmentOptions := []ent.EntitlementOption{
@@ -96,44 +95,42 @@ func (r *roleResourceType) Entitlements(ctx context.Context, resource *v2.Resour
 		ent.WithDescription(fmt.Sprintf("%s role in HubSpot", resource.DisplayName)),
 	}
 
-	// create membership entitlement
 	rv = append(rv, ent.NewAssignmentEntitlement(
 		resource,
 		roleMembership,
 		assignmentOptions...,
 	))
 
-	return rv, "", nil, nil
+	return rv, nil, nil
 }
 
-func (r *roleResourceType) Grants(ctx context.Context, resource *v2.Resource, token *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
-	bag, err := parsePageToken(token.Token, &v2.ResourceId{ResourceType: resourceTypeUser.Id})
+func (r *roleResourceType) Grants(ctx context.Context, resource *v2.Resource, opts rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
+	bag, err := parsePageToken(opts.PageToken.Token, &v2.ResourceId{ResourceType: resourceTypeUser.Id})
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
-	users, nextToken, annotations, err := r.client.GetUsers(ctx, hubspot.GetUsersVars{
+	users, nextToken, annos, err := r.client.GetUsers(ctx, hubspot.GetUsersVars{
 		Limit: ResourcesPageSize,
 		After: bag.PageToken(),
 	})
 	if err != nil {
-		return nil, "", nil, fmt.Errorf("hubspot-connector: failed to list users: %w", err)
+		return nil, nil, fmt.Errorf("hubspot-connector: failed to list users: %w", err)
 	}
 
 	pageToken, err := bag.NextToken(nextToken)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
-	// Parse the role id from the role profile
 	roleTrait, err := rs.GetRoleTrait(resource)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	roleId, ok := rs.GetProfileStringValue(roleTrait.Profile, "role_id")
 	if !ok {
-		return nil, "", nil, fmt.Errorf("hubspot-connector: error parsing role id from role profile")
+		return nil, nil, fmt.Errorf("hubspot-connector: error parsing role id from role profile")
 	}
 
 	var rv []*v2.Grant
@@ -146,17 +143,13 @@ func (r *roleResourceType) Grants(ctx context.Context, resource *v2.Resource, to
 
 	for _, user := range filteredUsers {
 		userResourceId := getUserResourceId(user.Id)
-		rv = append(rv, grant.NewGrant(
-			resource,
-			roleMembership,
-			userResourceId,
-		))
+		rv = append(rv, grant.NewGrant(resource, roleMembership, userResourceId))
 	}
 
-	return rv, pageToken, annotations, nil
+	return rv, &rs.SyncOpResults{NextPageToken: pageToken, Annotations: annos}, nil
 }
 
-func (r *roleResourceType) Grant(ctx context.Context, principal *v2.Resource, entitlement *v2.Entitlement) (annotations.Annotations, error) {
+func (r *roleResourceType) Grant(ctx context.Context, principal *v2.Resource, entitlement *v2.Entitlement) ([]*v2.Grant, annotations.Annotations, error) {
 	l := ctxzap.Extract(ctx)
 
 	if principal.Id.ResourceType != resourceTypeUser.Id {
@@ -166,17 +159,15 @@ func (r *roleResourceType) Grant(ctx context.Context, principal *v2.Resource, en
 			zap.String("principal_type", principal.Id.ResourceType),
 		)
 
-		return nil, fmt.Errorf("hubspot-connector: only users can be granted role membership")
+		return nil, nil, fmt.Errorf("hubspot-connector: only users can be granted role membership")
 	}
 
 	roleId := entitlement.Resource.Id.Resource
 
 	if roleId == superAdminRole {
-		return nil, fmt.Errorf("hubspot-connector: super admin role can not be provisioned via API")
+		return nil, nil, fmt.Errorf("hubspot-connector: super admin role can not be provisioned via API")
 	}
 
-	// no need to check current user role - only rewriting is supported
-	// grant role membership
 	annos, err := r.client.UpdateUser(
 		ctx,
 		principal.Id.Resource,
@@ -185,10 +176,10 @@ func (r *roleResourceType) Grant(ctx context.Context, principal *v2.Resource, en
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("hubspot-connector: failed to update user: %w", err)
+		return nil, nil, fmt.Errorf("hubspot-connector: failed to update user: %w", err)
 	}
 
-	return annos, nil
+	return nil, annos, nil
 }
 
 func (r *roleResourceType) Revoke(ctx context.Context, grant *v2.Grant) (annotations.Annotations, error) {
@@ -211,7 +202,6 @@ func (r *roleResourceType) Revoke(ctx context.Context, grant *v2.Grant) (annotat
 		return nil, fmt.Errorf("hubspot-connector: super admin role can not be revoked via API")
 	}
 
-	// revoke role membership
 	annos, err := r.client.UpdateUser(
 		ctx,
 		principal.Id.Resource,

--- a/pkg/connector/teams.go
+++ b/pkg/connector/teams.go
@@ -8,7 +8,6 @@ import (
 	"github.com/conductorone/baton-hubspot/pkg/hubspot"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
-	"github.com/conductorone/baton-sdk/pkg/pagination"
 	ent "github.com/conductorone/baton-sdk/pkg/types/entitlement"
 	grant "github.com/conductorone/baton-sdk/pkg/types/grant"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
@@ -60,14 +59,14 @@ func teamResource(team *hubspot.Team, parentResourceID *v2.ResourceId) (*v2.Reso
 	return resource, nil
 }
 
-func (t *teamResourceType) List(ctx context.Context, parentId *v2.ResourceId, _ *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+func (t *teamResourceType) List(ctx context.Context, parentId *v2.ResourceId, _ rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
 	if parentId == nil {
-		return nil, "", nil, nil
+		return nil, nil, nil
 	}
 
-	teams, annotations, err := t.client.GetTeams(ctx)
+	teams, annos, err := t.client.GetTeams(ctx)
 	if err != nil {
-		return nil, "", nil, fmt.Errorf("hubspot-connector: failed to list teams: %w", err)
+		return nil, nil, fmt.Errorf("hubspot-connector: failed to list teams: %w", err)
 	}
 
 	var rv []*v2.Resource
@@ -76,16 +75,16 @@ func (t *teamResourceType) List(ctx context.Context, parentId *v2.ResourceId, _ 
 
 		tResource, err := teamResource(&teamCopy, parentId)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		rv = append(rv, tResource)
 	}
 
-	return rv, "", annotations, nil
+	return rv, &rs.SyncOpResults{Annotations: annos}, nil
 }
 
-func (t *teamResourceType) Entitlements(ctx context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
+func (t *teamResourceType) Entitlements(_ context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
 	var rv []*v2.Entitlement
 	primaryAssignmentOptions := []ent.EntitlementOption{
 		ent.WithGrantableTo(resourceTypeUser),
@@ -98,7 +97,6 @@ func (t *teamResourceType) Entitlements(ctx context.Context, resource *v2.Resour
 		ent.WithDescription(fmt.Sprintf("Access to %s team in HubSpot", resource.DisplayName)),
 	}
 
-	// create membership entitlements
 	rv = append(
 		rv,
 		ent.NewAssignmentEntitlement(
@@ -113,13 +111,13 @@ func (t *teamResourceType) Entitlements(ctx context.Context, resource *v2.Resour
 		),
 	)
 
-	return rv, "", nil, nil
+	return rv, nil, nil
 }
 
-func (t *teamResourceType) Grants(ctx context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
+func (t *teamResourceType) Grants(ctx context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
 	teamTrait, err := rs.GetGroupTrait(resource)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	var primaryUserIDs, secondaryUserIDs []string
@@ -134,45 +132,30 @@ func (t *teamResourceType) Grants(ctx context.Context, resource *v2.Resource, _ 
 		secondaryUserIDs = strings.Split(secondaryUserIDsString, ",")
 	}
 
-	// create membership grants
 	var rv []*v2.Grant
 	for _, id := range primaryUserIDs {
 		user, _, err := t.client.GetUser(ctx, id)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		userResourceId := getUserResourceId(user.Id)
-		rv = append(
-			rv,
-			grant.NewGrant(
-				resource,
-				primaryMemberEntitlement,
-				userResourceId,
-			),
-		)
+		rv = append(rv, grant.NewGrant(resource, primaryMemberEntitlement, userResourceId))
 	}
 
 	for _, id := range secondaryUserIDs {
 		user, _, err := t.client.GetUser(ctx, id)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 		userResourceId := getUserResourceId(user.Id)
-		rv = append(
-			rv,
-			grant.NewGrant(
-				resource,
-				secondaryMemberEntitlement,
-				userResourceId,
-			),
-		)
+		rv = append(rv, grant.NewGrant(resource, secondaryMemberEntitlement, userResourceId))
 	}
 
-	return rv, "", nil, nil
+	return rv, nil, nil
 }
 
-func (t *teamResourceType) Grant(ctx context.Context, principal *v2.Resource, entitlement *v2.Entitlement) (annotations.Annotations, error) {
+func (t *teamResourceType) Grant(ctx context.Context, principal *v2.Resource, entitlement *v2.Entitlement) ([]*v2.Grant, annotations.Annotations, error) {
 	l := ctxzap.Extract(ctx)
 
 	if principal.Id.ResourceType != resourceTypeUser.Id {
@@ -182,7 +165,7 @@ func (t *teamResourceType) Grant(ctx context.Context, principal *v2.Resource, en
 			zap.String("principal_type", principal.Id.ResourceType),
 		)
 
-		return nil, fmt.Errorf("hubspot-connector: only users can be granted team membership")
+		return nil, nil, fmt.Errorf("hubspot-connector: only users can be granted team membership")
 	}
 
 	teamId := entitlement.Resource.Id.Resource
@@ -191,7 +174,7 @@ func (t *teamResourceType) Grant(ctx context.Context, principal *v2.Resource, en
 	// need to check principal role - without specifying role, it will be removed
 	user, _, err := t.client.GetUser(ctx, principal.Id.Resource)
 	if err != nil {
-		return nil, fmt.Errorf("hubspot-connector: failed to get user: %w", err)
+		return nil, nil, fmt.Errorf("hubspot-connector: failed to get user: %w", err)
 	}
 
 	// there is only one role supported so far
@@ -204,7 +187,7 @@ func (t *teamResourceType) Grant(ctx context.Context, principal *v2.Resource, en
 	switch entitlementId {
 	case primaryMemberEntitlement:
 		if user.TeamId == teamId {
-			return nil, fmt.Errorf("hubspot-connector: user is already a primary member of team %s", teamId)
+			return nil, nil, fmt.Errorf("hubspot-connector: user is already a primary member of team %s", teamId)
 		}
 
 		annos, err = t.client.UpdateUser(
@@ -216,11 +199,11 @@ func (t *teamResourceType) Grant(ctx context.Context, principal *v2.Resource, en
 			},
 		)
 		if err != nil {
-			return nil, fmt.Errorf("hubspot-connector: failed to update user: %w", err)
+			return nil, nil, fmt.Errorf("hubspot-connector: failed to update user: %w", err)
 		}
 	case secondaryMemberEntitlement:
 		if containsTeam(user.SecondaryTeamIDs, teamId) {
-			return nil, fmt.Errorf("hubspot-connector: user is already a secondary member of team %s", teamId)
+			return nil, nil, fmt.Errorf("hubspot-connector: user is already a secondary member of team %s", teamId)
 		}
 
 		annos, err = t.client.UpdateUser(
@@ -232,11 +215,11 @@ func (t *teamResourceType) Grant(ctx context.Context, principal *v2.Resource, en
 			},
 		)
 		if err != nil {
-			return nil, fmt.Errorf("hubspot-connector: failed to update user: %w", err)
+			return nil, nil, fmt.Errorf("hubspot-connector: failed to update user: %w", err)
 		}
 	}
 
-	return annos, nil
+	return nil, annos, nil
 }
 
 func (t *teamResourceType) Revoke(ctx context.Context, grant *v2.Grant) (annotations.Annotations, error) {

--- a/pkg/connector/teams.go
+++ b/pkg/connector/teams.go
@@ -133,26 +133,28 @@ func (t *teamResourceType) Grants(ctx context.Context, resource *v2.Resource, _ 
 	}
 
 	var rv []*v2.Grant
+	var annos annotations.Annotations
 	for _, id := range primaryUserIDs {
-		user, _, err := t.client.GetUser(ctx, id)
+		user, userAnnotations, err := t.client.GetUser(ctx, id)
 		if err != nil {
 			return nil, nil, err
 		}
-
+		annos.Merge(userAnnotations...)
 		userResourceId := getUserResourceId(user.Id)
 		rv = append(rv, grant.NewGrant(resource, primaryMemberEntitlement, userResourceId))
 	}
 
 	for _, id := range secondaryUserIDs {
-		user, _, err := t.client.GetUser(ctx, id)
+		user, userAnnotations, err := t.client.GetUser(ctx, id)
 		if err != nil {
 			return nil, nil, err
 		}
+		annos.Merge(userAnnotations...)
 		userResourceId := getUserResourceId(user.Id)
 		rv = append(rv, grant.NewGrant(resource, secondaryMemberEntitlement, userResourceId))
 	}
 
-	return rv, nil, nil
+	return rv, &rs.SyncOpResults{Annotations: annos}, nil
 }
 
 func (t *teamResourceType) Grant(ctx context.Context, principal *v2.Resource, entitlement *v2.Entitlement) ([]*v2.Grant, annotations.Annotations, error) {

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -151,13 +151,16 @@ func (u *userResourceType) List(ctx context.Context, parentId *v2.ResourceId, op
 			return nil, nil, err
 		}
 
-		userIDs := make([]string, 0, len(users))
-		for _, user := range users {
-			userIDs = append(userIDs, user.Id)
-		}
-		deletedSet, err := session.GetManyJSON[bool](ctx, opts.Session, userIDs, sessions.WithPrefix(deletedUsersSessionKey))
-		if err != nil {
-			return nil, nil, fmt.Errorf("hubspot-connector: failed to get deleted users from session: %w", err)
+		var deletedSet map[string]bool
+		if u.userStatus {
+			userIDs := make([]string, 0, len(users))
+			for _, user := range users {
+				userIDs = append(userIDs, user.Id)
+			}
+			deletedSet, err = session.GetManyJSON[bool](ctx, opts.Session, userIDs, sessions.WithPrefix(deletedUsersSessionKey))
+			if err != nil {
+				return nil, nil, fmt.Errorf("hubspot-connector: failed to get deleted users from session: %w", err)
+			}
 		}
 
 		var rv []*v2.Resource

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -164,10 +164,11 @@ func (u *userResourceType) List(ctx context.Context, parentId *v2.ResourceId, op
 		var rv []*v2.Resource
 		for _, user := range users {
 			userCopy := user
-			ur, _, err := u.userResource(ctx, &userCopy, parentId, deletedSet)
+			ur, userAnnotations, err := u.userResource(ctx, &userCopy, parentId, deletedSet)
 			if err != nil {
-				return nil, nil, err
+				return nil, &rs.SyncOpResults{Annotations: userAnnotations}, err
 			}
+			annos.Merge(userAnnotations...)
 			rv = append(rv, ur)
 		}
 

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -72,7 +72,7 @@ func (c *userResourceType) userResource(ctx context.Context, user *hubspot.User,
 		rs.WithParentResourceID(parentResourceID),
 	)
 	if err != nil {
-		return nil, nil, err
+		return nil, annos, err
 	}
 
 	return resource, annos, nil

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -3,13 +3,13 @@ package connector
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"github.com/conductorone/baton-hubspot/pkg/hubspot"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
-	"github.com/conductorone/baton-sdk/pkg/pagination"
+	"github.com/conductorone/baton-sdk/pkg/session"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+	"github.com/conductorone/baton-sdk/pkg/types/sessions"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
@@ -20,40 +20,29 @@ const (
 	PageTypeDeleted   = "DELETED_USERS"
 	PageTypeAllUsers  = "ALL_USERS"
 	PageTypeCompleted = "COMPLETED"
+
+	deletedUsersSessionKey = "deleted_users"
 )
 
 type userResourceType struct {
 	resourceType *v2.ResourceType
 	client       *hubspot.Client
 	userStatus   bool
-	deletedSet   map[string]bool
-	setMtx       sync.Mutex
 }
 
 func (u *userResourceType) ResourceType(_ context.Context) *v2.ResourceType {
 	return u.resourceType
 }
 
-func (c *userResourceType) cacheUsers(ids []string) error {
-	c.setMtx.Lock()
-	defer c.setMtx.Unlock()
-	if c.deletedSet == nil {
-		c.deletedSet = make(map[string]bool)
-	}
-	for _, user := range ids {
-		c.deletedSet[user] = true
-	}
-	return nil
-}
 
-// Create a new connector resource for an HubSpot user.
-func (c *userResourceType) userResource(ctx context.Context, user *hubspot.User, parentResourceID *v2.ResourceId) (*v2.Resource, annotations.Annotations, error) {
+// userResource creates a new connector resource for a HubSpot user.
+func (c *userResourceType) userResource(ctx context.Context, user *hubspot.User, parentResourceID *v2.ResourceId, deletedSet map[string]bool) (*v2.Resource, annotations.Annotations, error) {
 	profile := map[string]interface{}{
 		"login":   user.Email,
 		"user_id": user.Id,
 	}
 	userState := v2.UserTrait_Status_STATUS_ENABLED
-	if c.deletedSet[user.Id] {
+	if deletedSet[user.Id] {
 		userState = v2.UserTrait_Status_STATUS_DISABLED
 	}
 
@@ -77,13 +66,12 @@ func (c *userResourceType) userResource(ctx context.Context, user *hubspot.User,
 	}
 
 	resource, err := rs.NewUserResource(
-		user.Email, // email as a name
+		user.Email,
 		resourceTypeUser,
 		user.Id,
 		userTraitOptions,
 		rs.WithParentResourceID(parentResourceID),
 	)
-
 	if err != nil {
 		return nil, nil, err
 	}
@@ -91,18 +79,18 @@ func (c *userResourceType) userResource(ctx context.Context, user *hubspot.User,
 	return resource, nil, nil
 }
 
-func (u *userResourceType) List(ctx context.Context, parentId *v2.ResourceId, token *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+func (u *userResourceType) List(ctx context.Context, parentId *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
 	if parentId == nil {
-		return nil, "", nil, nil
+		return nil, nil, nil
 	}
-	bag, err := parsePageToken(token.Token, &v2.ResourceId{ResourceType: resourceTypeUser.Id})
+	bag, err := parsePageToken(opts.PageToken.Token, &v2.ResourceId{ResourceType: resourceTypeUser.Id})
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	userPageToken, err := unmarshalUserPageToken(bag.PageToken())
 	if err != nil {
-		return nil, "", nil, fmt.Errorf("failed to unmarshal the token %w", err)
+		return nil, nil, fmt.Errorf("failed to unmarshal the token %w", err)
 	}
 
 	if userPageToken.Type == "" && !u.userStatus {
@@ -111,45 +99,47 @@ func (u *userResourceType) List(ctx context.Context, parentId *v2.ResourceId, to
 
 	switch userPageToken.Type {
 	case "", PageTypeDeleted:
-		// Paginate over deleted users and populate deleted set.
-		deletedIDs, nextToken, annotation, err := u.client.GetDeletedUsers(ctx,
+		deletedIDs, nextToken, annos, err := u.client.GetDeletedUsers(ctx,
 			hubspot.GetUsersVars{Limit: ResourcesPageSize, After: userPageToken.Page},
 		)
 		if err != nil {
-			return nil, "", nil, fmt.Errorf("hubspot-connector: failed to get deactivated users: %w", err)
+			return nil, nil, fmt.Errorf("hubspot-connector: failed to get deactivated users: %w", err)
 		}
-		err = u.cacheUsers(deletedIDs)
-		if err != nil {
-			return nil, "", nil, fmt.Errorf("hubspot-connector: failed to get deactivated users: %w", err)
+
+		deletedMap := make(map[string]bool, len(deletedIDs))
+		for _, id := range deletedIDs {
+			deletedMap[id] = true
 		}
+		if err := session.SetManyJSON(ctx, opts.Session, deletedMap, sessions.WithPrefix(deletedUsersSessionKey)); err != nil {
+			return nil, nil, fmt.Errorf("hubspot-connector: failed to save deleted users to session: %w", err)
+		}
+
+		var nextPageType string
+		var nextPage string
 		if nextToken != "" {
-			parsedNextToken, err := parseUserPaginationToken(
-				UsersPaginationToken{Page: nextToken, Type: PageTypeDeleted},
-				bag,
-			)
-			if err != nil {
-				return nil, "", nil, err
-			}
-			return nil, parsedNextToken, annotation, nil
+			nextPageType = PageTypeDeleted
+			nextPage = nextToken
 		} else {
-			// no more deleted users, start PageTypeAllUsers pagination
-			parsedNextToken, err := parseUserPaginationToken(
-				UsersPaginationToken{Page: "", Type: PageTypeAllUsers},
-				bag,
-			)
-			if err != nil {
-				return nil, "", nil, err
-			}
-			return nil, parsedNextToken, annotation, nil
+			nextPageType = PageTypeAllUsers
 		}
+		parsedNextToken, err := parseUserPaginationToken(
+			UsersPaginationToken{Page: nextPage, Type: nextPageType},
+			bag,
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+		return nil, &rs.SyncOpResults{NextPageToken: parsedNextToken, Annotations: annos}, nil
+
 	case PageTypeAllUsers:
-		users, nextToken, annotations, err := u.client.GetUsers(
+		users, nextToken, annos, err := u.client.GetUsers(
 			ctx,
 			hubspot.GetUsersVars{Limit: ResourcesPageSize, After: userPageToken.Page},
 		)
 		if err != nil {
-			return nil, "", nil, fmt.Errorf("hubspot-connector: failed to list users: %w", err)
+			return nil, nil, fmt.Errorf("hubspot-connector: failed to list users: %w", err)
 		}
+
 		paginationType := PageTypeAllUsers
 		if nextToken == "" {
 			paginationType = PageTypeCompleted
@@ -159,34 +149,43 @@ func (u *userResourceType) List(ctx context.Context, parentId *v2.ResourceId, to
 			bag,
 		)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
+		}
+
+		userIDs := make([]string, 0, len(users))
+		for _, user := range users {
+			userIDs = append(userIDs, user.Id)
+		}
+		deletedSet, err := session.GetManyJSON[bool](ctx, opts.Session, userIDs, sessions.WithPrefix(deletedUsersSessionKey))
+		if err != nil {
+			return nil, nil, fmt.Errorf("hubspot-connector: failed to get deleted users from session: %w", err)
 		}
 
 		var rv []*v2.Resource
 		for _, user := range users {
 			userCopy := user
-			ur, annos, err := u.userResource(ctx, &userCopy, parentId)
+			ur, _, err := u.userResource(ctx, &userCopy, parentId, deletedSet)
 			if err != nil {
-				return nil, "", annos, err
+				return nil, nil, err
 			}
-
 			rv = append(rv, ur)
 		}
 
-		return rv, parsedNextToken, annotations, nil
+		return rv, &rs.SyncOpResults{NextPageToken: parsedNextToken, Annotations: annos}, nil
+
 	case PageTypeCompleted:
-		u.deletedSet = nil
-		return nil, "", nil, nil
+		return nil, nil, nil
 	}
-	return nil, "", nil, nil
+
+	return nil, nil, nil
 }
 
-func (u *userResourceType) Entitlements(ctx context.Context, resource *v2.Resource, token *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
-	return nil, "", nil, nil
+func (u *userResourceType) Entitlements(_ context.Context, _ *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
+	return nil, nil, nil
 }
 
-func (u *userResourceType) Grants(ctx context.Context, resource *v2.Resource, token *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
-	return nil, "", nil, nil
+func (u *userResourceType) Grants(_ context.Context, _ *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
+	return nil, nil, nil
 }
 
 func userBuilder(client *hubspot.Client, userStatus bool) *userResourceType {

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -34,7 +34,6 @@ func (u *userResourceType) ResourceType(_ context.Context) *v2.ResourceType {
 	return u.resourceType
 }
 
-
 // userResource creates a new connector resource for a HubSpot user.
 func (c *userResourceType) userResource(ctx context.Context, user *hubspot.User, parentResourceID *v2.ResourceId, deletedSet map[string]bool) (*v2.Resource, annotations.Annotations, error) {
 	profile := map[string]interface{}{
@@ -76,7 +75,7 @@ func (c *userResourceType) userResource(ctx context.Context, user *hubspot.User,
 		return nil, nil, err
 	}
 
-	return resource, nil, nil
+	return resource, annos, nil
 }
 
 func (u *userResourceType) List(ctx context.Context, parentId *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {


### PR DESCRIPTION
## Summary

- Migrates all resource syncers from `ResourceSyncer` to `ResourceSyncerV2`, updating `List`, `Entitlements`, `Grants`, and `Grant`/`Revoke` signatures to return `*rs.SyncOpResults` instead of separate `(string, annotations.Annotations)`
- Enables the session store (`WithSessionStoreEnabled`) and replaces the in-memory `deletedSet map[string]bool` + mutex with session-store-backed `SetManyJSON`/`GetManyJSON`, making deleted-user tracking safe across paginated sync phases
- Fixes dropped annotations from `GetUserLastLogin` — rate-limit headers are now merged into the page-level `SyncOpResults` instead of being silently discarded

## Pre-existing issues (out of scope)

Two bugs were identified during review but are intentionally not fixed here to keep this PR focused on the V2 migration:

- **CXH-1360** — team `Grant` returns a hard error instead of `GrantAlreadyExists` when a user is already a member in the same capacity
- **CXH-407** — team `Grant` fails when trying to assign a user to a team they already belong to in a different capacity (primary vs secondary)

The `GetRoles` error being swallowed (`_`) is **intentional**: the Roles API is only available on Professional/Enterprise plans, so lower-tier accounts would fail the entire sync if the error were propagated. The connector gracefully degrades to syncing only the hardcoded `super_admin` role.

## Test plan

- [x] Run `go build ./...` and `go test ./...`
- [x] Run connector with `--user-status` flag against a HubSpot trial with 54 active users and 1 deactivated user
- [x] Confirm 54 users synced, deactivated user shows `STATUS_DISABLED`, session cache shows `hits:1` for the deleted set lookup
- [x] Confirm active-user pagination fires (54 users > 50 page size)

🤖 Generated with [Claude Code](https://claude.com/claude-code)