### PR TITLE
docs: add BATON_PROVISIONING flag to Kubernetes secrets config

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -193,6 +193,9 @@ stringData:
 
   # Optional: include if you want to sync user statuses (requires the crm.objects.users.read scope on the private app)
   BATON_USER_STATUS: true
+
+  # Optional: include if you want C1 to provision access using this connector
+  BATON_PROVISIONING: true
 ```
 
 See the connector's README or run `--help` to see all available configuration flags and environment variables.


### PR DESCRIPTION
## Summary

The `docs/connector.mdx` Kubernetes secrets configuration was missing `BATON_PROVISIONING: true`. Added the flag with the standard explanatory comment to match the pattern used in other provisioning-capable connector docs.

This mirrors the fix applied to the main ConductorOne/docs site in PR #245.