### PR TITLE
fix: raise ResourcesPageSize to 1000 for HubSpot user sync

### DIFF
--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -11,7 +11,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-var ResourcesPageSize = 50
+var ResourcesPageSize = 1000
 
 const (
 	profileFieldEmail            = "email"

--- a/pkg/hubspot/client.go
+++ b/pkg/hubspot/client.go
@@ -237,6 +237,11 @@ func (c *Client) UpdateUser(ctx context.Context, userId string, payload *UpdateU
 }
 
 func (c *Client) GetDeletedUsers(ctx context.Context, pageOptions GetUsersVars) ([]string, string, annotations.Annotations, error) {
+	// CRM object search rejects limit > 100 (settings/users allows larger pages).
+	limit := pageOptions.Limit
+	if limit <= 0 || limit > 100 {
+		limit = 100
+	}
 	userFilter := Filter{
 		PropertieName: "hs_deactivated",
 		Operator:      EqualOperator,
@@ -246,7 +251,7 @@ func (c *Client) GetDeletedUsers(ctx context.Context, pageOptions GetUsersVars) 
 	payload := SearchUserObjectPayload{
 		FilterGroups: filters,
 		Properties:   []string{"hs_deactivated", HSInternalUserId},
-		Limit:        pageOptions.Limit,
+		Limit:        limit,
 		After:        pageOptions.After,
 	}
 	var res SearchUserObjectResponse


### PR DESCRIPTION
## Summary

HubSpot `GET /settings/users/2026-03?limit=N` returns at most N results and **does not** include `paging` / `next.after` even when more users exist. The connector used `ResourcesPageSize = 50`, so user syncs stopped at 50 users.

This change raises `ResourcesPageSize` from **50** to **1000** as a mitigation for tenants with ≤1000 users. A proper fix would restore cursor-based pagination (e.g. via the v3 users API that still returns cursors); that is out of scope here.

## Change

- `pkg/connector/helpers.go`: `var ResourcesPageSize = 1000` (was `50`) — used by settings/users list calls (user, account, role)
- `pkg/hubspot/client.go`: clamp CRM search (`GetDeletedUsers`) limit to 100 — HubSpot `/crm/v3/objects/users/search` rejects `limit > 100`, so the larger settings page size must not be passed through to deactivated-user search

## Test plan

- [x] `go test ./...` passes
- [x] CI Grant/Revoke integration sync (uses deactivated-user path when user status enabled)
- [ ] Verify user sync on a HubSpot tenant with >50 users returns the full set (up to 1000)