### PR TITLE
fix: GetUsers list via settings/users/2026-09-beta for pagination

### DIFF
--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -36,15 +36,12 @@ func roleResource(role *hubspot.Role, parentResourceID *v2.ResourceId) (*v2.Reso
 		"role_name":        displayName,
 	}
 
-	roleTraitOptions := []rs.RoleTraitOption{
-		rs.WithRoleProfile(profile),
-	}
-
 	resource, err := rs.NewRoleResource(
 		displayName,
 		resourceTypeRole,
 		role.Id,
-		roleTraitOptions,
+		nil,
+		rs.WithResourceProfile(profile),
 		rs.WithParentResourceID(parentResourceID),
 	)
 
@@ -123,12 +120,7 @@ func (r *roleResourceType) Grants(ctx context.Context, resource *v2.Resource, op
 		return nil, nil, err
 	}
 
-	roleTrait, err := rs.GetRoleTrait(resource)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	roleId, ok := rs.GetProfileStringValue(roleTrait.Profile, profileFieldRoleID)
+	roleId, ok := rs.GetProfileStringValue(rs.GetProfile(resource), profileFieldRoleID)
 	if !ok {
 		return nil, nil, fmt.Errorf("hubspot-connector: error parsing role id from role profile")
 	}

--- a/pkg/connector/teams.go
+++ b/pkg/connector/teams.go
@@ -48,7 +48,8 @@ func teamResource(team *hubspot.Team, parentResourceID *v2.ResourceId) (*v2.Reso
 		team.Name,
 		resourceTypeTeam,
 		team.Id,
-		[]rs.GroupTraitOption{rs.WithGroupProfile(profile)},
+		nil,
+		rs.WithResourceProfile(profile),
 		rs.WithParentResourceID(parentResourceID),
 	)
 
@@ -115,19 +116,15 @@ func (t *teamResourceType) Entitlements(_ context.Context, resource *v2.Resource
 }
 
 func (t *teamResourceType) Grants(ctx context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
-	teamTrait, err := rs.GetGroupTrait(resource)
-	if err != nil {
-		return nil, nil, err
-	}
-
 	var primaryUserIDs, secondaryUserIDs []string
+	profile := rs.GetProfile(resource)
 
-	primaryUserIDsString, ok := rs.GetProfileStringValue(teamTrait.Profile, "team_primary_users")
+	primaryUserIDsString, ok := rs.GetProfileStringValue(profile, "team_primary_users")
 	if ok {
 		primaryUserIDs = strings.Split(primaryUserIDsString, ",")
 	}
 
-	secondaryUserIDsString, ok := rs.GetProfileStringValue(teamTrait.Profile, "team_secondary_users")
+	secondaryUserIDsString, ok := rs.GetProfileStringValue(profile, "team_secondary_users")
 	if ok {
 		secondaryUserIDs = strings.Split(secondaryUserIDsString, ",")
 	}

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -54,9 +54,7 @@ func (c *userResourceType) userResource(
 	}
 
 	userTraitOptions := []rs.UserTraitOption{
-		rs.WithUserProfile(profile),
 		rs.WithEmail(user.Email, true),
-		rs.WithStatus(userState),
 	}
 
 	var annos annotations.Annotations
@@ -83,6 +81,8 @@ func (c *userResourceType) userResource(
 		user.Id,
 		userTraitOptions,
 		rs.WithParentResourceID(parentResourceID),
+		rs.WithResourceProfile(profile),
+		rs.WithResourceStatus(v2.Status_ResourceStatus(userState), ""),
 	)
 	if err != nil {
 		return nil, annos, err

--- a/pkg/hubspot/client.go
+++ b/pkg/hubspot/client.go
@@ -28,6 +28,12 @@ func (c *Client) usersURL() string {
 	return c.baseURL.JoinPath("settings/users/2026-03").String()
 }
 
+// listUsersURL is the paginated list endpoint. 2026-09-beta returns
+// paging.next.after with limit=50; 2026-03 omits paging and silently truncates.
+func (c *Client) listUsersURL() string {
+	return c.baseURL.JoinPath("settings/users/2026-09-beta").String()
+}
+
 func (c *Client) userURL(userID string) string {
 	return c.baseURL.JoinPath("settings/users/2026-03", userID).String()
 }
@@ -138,7 +144,7 @@ func (c *Client) GetUsers(ctx context.Context, getUsersVars GetUsersVars) ([]Use
 
 	annos, err := c.get(
 		ctx,
-		c.usersURL(),
+		c.listUsersURL(),
 		&userResponse,
 		queryParams,
 	)


### PR DESCRIPTION
## Summary

HubSpot's `GET /settings/users/2026-03?limit=50` returns 50 users but **omits the `paging` key**, so connectors stop after the first page and silently drop the rest of the directory.

`GET /settings/users/2026-09-beta?limit=50` returns the same page size **with `paging.next.after`**, so page 2+ works.

### Change
- Add `listUsersURL()` → `settings/users/2026-09-beta`
- Route **only** `GetUsers` through that helper
- Leave `InviteUser` / `DeleteUser` / `GetUser` / teams / roles on `settings/users/2026-03`
- **Do not** raise `ResourcesPageSize` (stays 50)

### Why not page size 1000
A larger page size is a workaround for missing cursor paging and can still truncate or hit API limits. Cursor paging on 2026-09-beta is the correct fix.

## Test plan
- [x] `go test ./...` passes
- [x] `rg` confirms GetUsers uses 2026-09-beta; invite/delete/get-one remain on 2026-03
- [x] `ResourcesPageSize` still 50
- [ ] Live sync against a HubSpot tenant with >50 users shows multi-page user list